### PR TITLE
Use ember destroyable polyfill for teardown

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "ember-cli-babel": "^7.19.0",
     "ember-cli-htmlbars": "^4.3.1",
     "ember-cli-typescript": "^3.1.4",
+    "ember-destroyable-polyfill": "^2.0.1",
     "ember-get-config": "^0.2.4",
     "pusher-js": "^6.0.3",
     "pusher-js-mock": "^0.3.3"

--- a/tests/unit/services/pusher-test.js
+++ b/tests/unit/services/pusher-test.js
@@ -2,37 +2,51 @@ import Controller from '@ember/controller';
 import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
 import { PusherChannelMock } from 'pusher-js-mock';
+import { settled } from '@ember/test-helpers';
 
 module('Unit | Service | pusher | classic', function(hooks) {
   setupTest(hooks);
 
+  let service;
+
+  hooks.afterEach(() => {
+    if (service) {
+      service.unsubscribeAll();
+    }
+  });
+
   // Replace this with your real tests.
   test('it exists', function(assert) {
-    let service = this.owner.lookup('service:pusher');
+    service = this.owner.lookup('service:pusher');
     assert.ok(service);
   });
 
   test('#subscribe', function(assert) {
-    let service = this.owner.lookup('service:pusher');
+    service = this.owner.lookup('service:pusher');
 
     const channel = service.subscribe('channel-1');
     assert.equal(channel instanceof PusherChannelMock, true);
     assert.equal(channel.name, 'channel-1');
   });
 
-  test('#wire', function(assert) {
-    let service = this.owner.lookup('service:pusher');
+  test('#wire', async function(assert) {
+    service = this.owner.lookup('service:pusher');
     const target = TestController.create();
     const targetId = target.toString();
     service.wire(target, 'channel-1', ['new-message']);
-    assert.ok(service.bindings['channel-1']);
-    assert.ok(service.bindings['channel-1'].events[targetId]);
-    assert.equal(service.bindings['channel-1'].events[target.toString()].length, 1);
-    assert.deepEqual(Object.keys(service.client.channels), ['channel-1']);
+    assert.ok(service.bindings['channel-1'], 'should add a binding entry for the channel passed');
+    assert.ok(service.bindings['channel-1'].events[targetId], 'should add an events array on the binding entry for the target ID');
+    assert.equal(service.bindings['channel-1'].events[target.toString()].length, 1, 'should add an object to the target\'s events array');
+    assert.deepEqual(Object.keys(service.client.channels), ['channel-1'], 'should subscribe via pusherjs to channel passed in');
+    // Test auto-unwire on object destruction
+    target.destroy();
+    await settled();
+    assert.notOk(service.bindings['channel-1'], 'should remove channel binding on destroy');
+    assert.deepEqual(Object.keys(service.client.channels), [], 'should unsubscribe via pusherjs on destroy');
   });
 
   test('#wireSubscriptions', function(assert) {
-    let service = this.owner.lookup('service:pusher');
+    service = this.owner.lookup('service:pusher');
     const target = TestController.create();
     const targetId = target.toString();
     service.wireSubscriptions(target);
@@ -40,14 +54,10 @@ module('Unit | Service | pusher | classic', function(hooks) {
     assert.ok(service.bindings['channel-1'].events[targetId]);
     assert.equal(service.bindings['channel-1'].events[target.toString()].length, 1);
     assert.deepEqual(Object.keys(service.client.channels), ['channel-1']);
-    // Make sure willDestroy was update to unwire
-    target.willDestroy();
-    assert.notOk(service.bindings['channel-1']);
-    assert.deepEqual(Object.keys(service.client.channels), []);
   });
 
   test('#unwire', function(assert) {
-    let service = this.owner.lookup('service:pusher');
+    service = this.owner.lookup('service:pusher');
     const target = TestController.create();
     service.wireSubscriptions(target);
     service.unwire(target, 'channel-1', ['new-message']);

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -21,6 +21,9 @@
     "module": "es6",
     "experimentalDecorators": true,
     "paths": {
+      "@ember/destroyable": [
+        "node_modules/ember-destroyable-polyfill"
+      ],
       "dummy/tests/*": [
         "tests/*"
       ],

--- a/tslint.json
+++ b/tslint.json
@@ -1,0 +1,9 @@
+{
+    "defaultSeverity": "error",
+    "extends": [
+        "tslint:recommended"
+    ],
+    "jsRules": {},
+    "rules": {},
+    "rulesDirectory": []
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -4731,7 +4731,7 @@ ember-cli-babel@^6.0.0-beta.4, ember-cli-babel@^6.3.0, ember-cli-babel@^6.6.0, e
     ember-cli-version-checker "^2.1.2"
     semver "^5.5.0"
 
-ember-cli-babel@^7.1.2, ember-cli-babel@^7.11.0, ember-cli-babel@^7.12.0, ember-cli-babel@^7.13.2, ember-cli-babel@^7.18.0, ember-cli-babel@^7.19.0, ember-cli-babel@^7.20.5, ember-cli-babel@^7.7.3:
+ember-cli-babel@^7.1.2, ember-cli-babel@^7.11.0, ember-cli-babel@^7.12.0, ember-cli-babel@^7.13.2, ember-cli-babel@^7.18.0, ember-cli-babel@^7.19.0, ember-cli-babel@^7.20.5, ember-cli-babel@^7.22.1, ember-cli-babel@^7.7.3:
   version "7.22.1"
   resolved "https://registry.yarnpkg.com/ember-cli-babel/-/ember-cli-babel-7.22.1.tgz#cad28b89cf0e184c93b863d09bc5ba4ce1d2e453"
   integrity sha512-kCT8WbC1AYFtyOpU23ESm22a+gL6fWv8Nzwe8QFQ5u0piJzM9MEudfbjADEaoyKTrjMQTDsrWwEf3yjggDsOng==
@@ -5069,7 +5069,7 @@ ember-cli@~3.18.0:
     watch-detector "^1.0.0"
     yam "^1.0.0"
 
-ember-compatibility-helpers@^1.1.2:
+ember-compatibility-helpers@^1.1.2, ember-compatibility-helpers@^1.2.1:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/ember-compatibility-helpers/-/ember-compatibility-helpers-1.2.1.tgz#87c92c4303f990ff455c28ca39fb3ee11441aa16"
   integrity sha512-6wzYvnhg1ihQUT5yGqnLtleq3Nv5KNv79WhrEuNU9SwR4uIxCO+KpyC7r3d5VI0EM7/Nmv9Nd0yTkzmTMdVG1A==
@@ -5077,6 +5077,15 @@ ember-compatibility-helpers@^1.1.2:
     babel-plugin-debug-macros "^0.2.0"
     ember-cli-version-checker "^2.1.1"
     semver "^5.4.1"
+
+ember-destroyable-polyfill@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/ember-destroyable-polyfill/-/ember-destroyable-polyfill-2.0.1.tgz#391cd95a99debaf24148ce953054008d00f151a6"
+  integrity sha512-hyK+/GPWOIxM1vxnlVMknNl9E5CAFVbcxi8zPiM0vCRwHiFS8Wuj7PfthZ1/OFitNNv7ITTeU8hxqvOZVsrbnQ==
+  dependencies:
+    ember-cli-babel "^7.22.1"
+    ember-cli-version-checker "^5.1.1"
+    ember-compatibility-helpers "^1.2.1"
 
 ember-disable-prototype-extensions@^1.1.3:
   version "1.1.3"


### PR DESCRIPTION
Includes:

- Add tslint and replace `Function` types with signatures
- Add teardown hook for unit tests