### PR TITLE
Gracefully handle missing binding & events cases

### DIFF
--- a/addon/services/pusher.ts
+++ b/addon/services/pusher.ts
@@ -119,6 +119,8 @@ export default class PusherService extends Service {
     const targetId = target.toString();
     const events = this.bindings[channelName].events[targetId];
 
+    if (!events) { return; }
+
     events.forEach((evt) => {
       channel.unbind(evt.name, evt.handler);
     });

--- a/addon/services/pusher.ts
+++ b/addon/services/pusher.ts
@@ -113,6 +113,8 @@ export default class PusherService extends Service {
   }
 
   public unwire(target: PusherSubscriber, channelName: string): void {
+    if (!this.bindings[channelName]) { return; }
+
     const { channel } = this.bindings[channelName];
     const targetId = target.toString();
     const events = this.bindings[channelName].events[targetId];


### PR DESCRIPTION
Fixes a significant number of errors in our production logs likely linked to race conditions the unwire function.